### PR TITLE
Deployment

### DIFF
--- a/WebApp/static/css/style.css
+++ b/WebApp/static/css/style.css
@@ -6,6 +6,10 @@
     background-color: tan;
 }
 
+.jumbotron {
+    background: none;
+}
+
 .img-responsive {
     width: 100%;
     height: 100%;

--- a/WebApp/templates/index.html
+++ b/WebApp/templates/index.html
@@ -13,7 +13,8 @@
 
 <body>
     <div class="wrapper">
-        <div class="col-md-12 jumbotron text-center">
+        <div class="col-md-12 jumbotron text-center"
+            style="background: none; border-bottom: 3px groove rgb(156, 86, 86, .7);">
             <h1>Hall of Fame Players</h1>
             <p><a class="btn btn-primary btn-lg" href="/scrape" role="button">See What's New In Cooperstown</a>
             </p>

--- a/WebApp/templates/index.html
+++ b/WebApp/templates/index.html
@@ -41,7 +41,7 @@
             </div>
             <div class="col-md-5">
                 <h2>Newest from HOF Historical Image Gallery</h2>
-                <img src="{{hall.featured_image }}" class="img-responsive" alt="Responsive image" />
+                <img src="{{hall.featured_image }}" class="img-responsive w-100" alt="Responsive image" />
             </div>
         </div>
         <div class="row">


### PR DESCRIPTION
quick changes to the jumbotron:

- made the background opaque in anticipation of the Navbar/MLB logo adding a sleeker look
- create a "groove" border in Maroon separating the Jumbotron and rest of the body
- Gallery image wasn't fitting to the page in chrome - made styling changes for cross-browser compatibility 